### PR TITLE
Add configuration validation and tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+import pytest
+
+import main
+
+
+def test_validate_config_success(monkeypatch):
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_HASH", "hash")
+    monkeypatch.setenv("BOT_TOKEN", "token")
+    monkeypatch.setenv("CHANNEL_USERNAME", "chan")
+    monkeypatch.setenv("SHEET_URL", "url")
+    monkeypatch.setenv("GOOGLE_CREDENTIALS", "/tmp/creds.json")
+    importlib.reload(main)
+    config = main.validate_config()
+    assert config["API_ID"] == 123
+
+
+def test_validate_config_missing(monkeypatch):
+    monkeypatch.setenv("API_HASH", "hash")
+    monkeypatch.setenv("BOT_TOKEN", "token")
+    monkeypatch.setenv("CHANNEL_USERNAME", "chan")
+    monkeypatch.setenv("SHEET_URL", "url")
+    monkeypatch.setenv("GOOGLE_CREDENTIALS", "/tmp/creds.json")
+    importlib.reload(main)
+    monkeypatch.delenv("API_ID", raising=False)
+    with pytest.raises(SystemExit):
+        main.validate_config()


### PR DESCRIPTION
## Summary
- verify all required environment variables before creating the Telegram client
- exit with error logging when configuration is incomplete
- prevent side effects on module import and add `main()` entry point
- add unit tests for configuration validation

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741ec612888325a0784b9f0497f083