### PR TITLE
Add OCR functionality for image messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytz
 google-auth
 google-auth-oauthlib
 google-auth-httplib2
+pytesseract
+Pillow


### PR DESCRIPTION
## Summary
- add pytesseract and Pillow dependencies
- extract text from images in Telegram messages using pytesseract
- store OCR'd questions when detected

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68741ff177c0832595e3c65c23ca3647