### PR TITLE
Add question categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This bot collects questions from a Telegram channel and writes them to a Google Sheet.
 
+Each question is tagged with zero or more **categories** (e.g. `pediatrics`, `pharmacology`) based on keywords. These tags are stored in a new column in the sheet.
+
 ## Environment Variables
 Create a `.env` file containing the following keys:
 

--- a/tests/test_categorization.py
+++ b/tests/test_categorization.py
@@ -1,0 +1,8 @@
+import main
+
+
+def test_categorize_question_matches_keywords():
+    cats = main.categorize_question("A pediatric dose question about a drug")
+    assert "pediatrics" in cats
+    assert "pharmacology" in cats
+

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,9 +8,9 @@ def test_question_signature_normalization():
 def test_dedupe_rows():
     sig = main.question_signature("duplicate question")
     rows = [
-        ["t", "2025-01-01", "1", "u", "duplicate question", "No", ""],
-        ["t", "2025-01-01", "2", "u2", "duplicate question!!", "No", ""],
-        ["t", "2025-01-01", "3", "u3", "unique question", "No", ""],
+        ["t", "2025-01-01", "1", "u", "duplicate question", "No", "", ""],
+        ["t", "2025-01-01", "2", "u2", "duplicate question!!", "No", "", ""],
+        ["t", "2025-01-01", "3", "u3", "unique question", "No", "", ""],
     ]
     deduped = main.dedupe_rows(rows, {sig})
     assert len(deduped) == 1


### PR DESCRIPTION
## Summary
- categorize questions using keyword sets such as pediatrics or pharmacology
- store categories in an extra spreadsheet column
- document the new feature
- test the categorization function

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742b192ab083258eb5d85e693dbe13